### PR TITLE
ci: simplify workflow steps and group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      ci:
+        patterns:
+          - "*"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,18 +20,14 @@ jobs:
   Check:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
-      - name: Install Dependencies
-        run: npm install
-      - name: Check Formatting
-        run: npm run check
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - run: npm install
+      - run: npm run check
 
   Test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@v4.2.2 # immutable action, safe to use a version instead of hashtag
       - name: Run
         id: create
         uses: ./


### PR DESCRIPTION
Remove explicit step names in the checks workflow to streamline the YAML
and reduce verbosity without changing functionality. Add a Dependabot
group for CI-related dependencies to consolidate update PRs and improve
dependency management efficiency.