### PR TITLE
chore(ci): pin actions/checkout to immutable commit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,14 +20,14 @@ jobs:
   Check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm install
       - run: npm run check
 
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action, safe to use a version instead of hashtag
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Run
         id: create
         uses: ./

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5.0.0 # immutable action
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: npm install
       - run: npm run all
       - name: Checking Git


### PR DESCRIPTION
Update CI workflow files to reference a specific commit for
actions/checkout instead of the floating v5.0.0 tag. This pins
the action to commit 08c6903cd8c0fde910a37f88322edcfb5dd907a8 in both
update-dist.yml and checks.yml.

This prevents unexpected behavior from future changes to the v5
tag and ensures reproducible CI runs while keeping the tag noted
in the comment for clarity.