### PR TITLE
chore(actions): update checkout action to v5 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The action uses GitHub API to get the list of changed files.
 ## Example
 
 ```yaml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v5
 - uses: sv-tools/block-merge-conflicts@v2
   with:
     token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update GitHub Actions workflow example in README to use
actions/checkout@v5 instead of v3. This brings the example up to
date with the latest stable major version and ensures compatibility
with newer runner features and fixes.